### PR TITLE
Automatically `dnf clean all` after packages

### DIFF
--- a/src/blueprint.rs
+++ b/src/blueprint.rs
@@ -88,6 +88,9 @@ impl Render for Packages {
             .chain(packages)
             .collect::<Vec<_>>();
         out.exec.push(crate::ExecuteCommand(cmd));
+        out.exec_cleanup
+            .entry("dnf-clean".to_owned())
+            .or_insert_with(|| crate::ExecuteCommand::new(["dnf", "clean", "all"]));
         Ok(true)
     }
 }


### PR DESCRIPTION
This is part of what being declarative gets us.
(And we should clean out the other dnf cruft too in /var/log etc.)